### PR TITLE
Make sure move target isn't ancestor of the move anchor

### DIFF
--- a/whale/util.go
+++ b/whale/util.go
@@ -6,6 +6,16 @@ import (
 )
 
 func MoveFunc(what, where xml.Node, position Position) {
+
+	ancestor := where.Parent()
+	for ancestor != nil {
+		if what.NodePtr() == ancestor.NodePtr() {
+			// @ZC: Should we warn or err silently?
+			return
+		}
+		ancestor = ancestor.Parent()
+	}
+
 	switch position {
 	case BOTTOM:
 		where.AddChild(what)


### PR DESCRIPTION
This fixes the case we're seeing on gettington, but it breaks a test case (move_and_select) in the libxml suite.

Let's revisit the test, because this fix produces the output I'd expect, but not what the test expects.
