### PR TITLE
Deleting an incorrect use case for the clear function

### DIFF
--- a/packages/base/functions.ts
+++ b/packages/base/functions.ts
@@ -284,7 +284,6 @@
 # The `clear` function is used to remove text from inside a text scope.
 # *Related functions*: [remove()][1]
 # ### Common Uses
-# * Clearing extra white space inside nodes
 # * Clearing text links to turn them into icons
 # 
 # In the following example, we simply clear any existing text inside the node with an ID of `my_div`.


### PR DESCRIPTION
The clear function can't easily be used to remove whitespace from a node. Clearing that issue up with this PR.
