### PR TITLE
[PFST-185] Fix libxml memory leak in tritium interface layer.

### DIFF
--- a/htmltransformer/gokogiri_interface/htmltransformer.go
+++ b/htmltransformer/gokogiri_interface/htmltransformer.go
@@ -53,7 +53,7 @@ func (xform *GokogiriHtmlTransformer) Root() (ht.Node, ht.Node) {
 		return &GokogiriXmlNode{xform.document}, &GokogiriXmlNode{xform.document.Root()}
 	} else {
 		// we don't care if it's nil here
-		return &GokogiriXmlNode{xform.fragment}, nil
+		return &GokogiriXmlNode{xform.document}, &GokogiriXmlNode{xform.fragment}
 	}
 }
 
@@ -93,6 +93,7 @@ func (xform *GokogiriHtmlTransformer) ParseFragment(content, inEncoding, url, ou
 		fragment, err = newdoc.ParseFragment(content, url, xml.DefaultParseOption)
 	} else {
 		fragment, err = html.ParseFragment(content, inEncoding, url, html.DefaultParseOption, outEncoding)
+		xform.document = xml.NewDocument(fragment.Node.MyDocument().DocPtr(), len(content), inEncoding, outEncoding)
 	}
 	xform.fragment = fragment
 	if err != nil {

--- a/htmltransformer/gokogiri_interface/htmltransformer.go
+++ b/htmltransformer/gokogiri_interface/htmltransformer.go
@@ -11,6 +11,7 @@ import (
 
 type GokogiriHtmlTransformer struct {
 	document *xml.XmlDocument
+	mydoc    xml.Document
 	fragment *xml.DocumentFragment
 }
 
@@ -64,6 +65,9 @@ func (xform *GokogiriHtmlTransformer) Free() {
 	if xform.fragment != nil {
 		xform.fragment.Remove()
 	}
+	if xform.mydoc != nil {
+		xform.mydoc.Free()
+	}
 }
 
 func (xform *GokogiriHtmlTransformer) SetMetaEncoding(encoding string) (err error) {
@@ -93,7 +97,14 @@ func (xform *GokogiriHtmlTransformer) ParseFragment(content, inEncoding, url, ou
 		fragment, err = newdoc.ParseFragment(content, url, xml.DefaultParseOption)
 	} else {
 		fragment, err = html.ParseFragment(content, inEncoding, url, html.DefaultParseOption, outEncoding)
-		xform.document = xml.NewDocument(fragment.Node.MyDocument().DocPtr(), len(content), inEncoding, outEncoding)
+		switch doctype := fragment.Node.MyDocument().(type) {
+		case *html.HtmlDocument:
+			xform.document = doctype.XmlDocument
+		case *xml.XmlDocument:
+			xform.document = doctype
+		default:
+			xform.mydoc = doctype
+		}
 	}
 	xform.fragment = fragment
 	if err != nil {

--- a/htmltransformer/gokogiri_interface_legacy/htmltransformer.go
+++ b/htmltransformer/gokogiri_interface_legacy/htmltransformer.go
@@ -92,7 +92,9 @@ func (xform *GokogiriHtmlTransformer) ParseFragment(content, inEncoding, url, ou
 		newdoc := html.HtmlDocument{xform.document}
 		fragment, err = newdoc.ParseFragment(content, url, xml.DefaultParseOption)
 	} else {
-		fragment, err = html.ParseFragment(content, inEncoding, url, html.DefaultParseOption, outEncoding)
+		xform.CreateEmptyDocument(nil, nil)
+		newdoc := html.HtmlDocument{xform.document}
+		fragment, err = newdoc.ParseFragment(content, url, xml.DefaultParseOption)
 	}
 	xform.fragment = fragment
 	if err != nil {

--- a/htmltransformer/gokogiri_interface_legacy/htmltransformer.go
+++ b/htmltransformer/gokogiri_interface_legacy/htmltransformer.go
@@ -53,7 +53,7 @@ func (xform *GokogiriHtmlTransformer) Root() (ht.Node, ht.Node) {
 		return &GokogiriXmlNode{xform.document}, &GokogiriXmlNode{xform.document.Root()}
 	} else {
 		// we don't care if it's nil here
-		return &GokogiriXmlNode{xform.fragment}, nil
+		return &GokogiriXmlNode{xform.document}, &GokogiriXmlNode{xform.fragment}
 	}
 }
 
@@ -92,9 +92,8 @@ func (xform *GokogiriHtmlTransformer) ParseFragment(content, inEncoding, url, ou
 		newdoc := html.HtmlDocument{xform.document}
 		fragment, err = newdoc.ParseFragment(content, url, xml.DefaultParseOption)
 	} else {
-		xform.CreateEmptyDocument(nil, nil)
-		newdoc := html.HtmlDocument{xform.document}
-		fragment, err = newdoc.ParseFragment(content, url, xml.DefaultParseOption)
+		fragment, err = html.ParseFragment(content, inEncoding, url, html.DefaultParseOption, outEncoding)
+		xform.document = xml.NewDocument(fragment.Node.MyDocument().DocPtr(), len(content), inEncoding, outEncoding)
 	}
 	xform.fragment = fragment
 	if err != nil {

--- a/htmltransformer/gokogiri_interface_legacy/htmltransformer.go
+++ b/htmltransformer/gokogiri_interface_legacy/htmltransformer.go
@@ -11,6 +11,7 @@ import (
 
 type GokogiriHtmlTransformer struct {
 	document *xml.XmlDocument
+	mydoc    xml.Document
 	fragment *xml.DocumentFragment
 }
 
@@ -64,6 +65,9 @@ func (xform *GokogiriHtmlTransformer) Free() {
 	if xform.fragment != nil {
 		xform.fragment.Remove()
 	}
+	if xform.mydoc != nil {
+		xform.mydoc.Free()
+	}
 }
 
 func (xform *GokogiriHtmlTransformer) SetMetaEncoding(encoding string) (err error) {
@@ -93,7 +97,14 @@ func (xform *GokogiriHtmlTransformer) ParseFragment(content, inEncoding, url, ou
 		fragment, err = newdoc.ParseFragment(content, url, xml.DefaultParseOption)
 	} else {
 		fragment, err = html.ParseFragment(content, inEncoding, url, html.DefaultParseOption, outEncoding)
-		xform.document = xml.NewDocument(fragment.Node.MyDocument().DocPtr(), len(content), inEncoding, outEncoding)
+		switch doctype := fragment.Node.MyDocument().(type) {
+		case *html.HtmlDocument:
+			xform.document = doctype.XmlDocument
+		case *xml.XmlDocument:
+			xform.document = doctype
+		default:
+			xform.mydoc = doctype
+		}
 	}
 	xform.fragment = fragment
 	if err != nil {

--- a/whale/builtin.go
+++ b/whale/builtin.go
@@ -98,6 +98,7 @@ func init() {
 	// jsonlib/jsonlib_primitives
 	builtInFunctions["tritium.to_json_v1.Text"] = to_json_v1_Text
 	builtInFunctions["tritium.json_to_xml_v1"] = json_to_xml_v1
+	builtInFunctions["tritium.json_to_xml_libxml_292"] = json_to_xml_libxml_292
 
 	// core-rewriter/header_primitives
 	builtInFunctions["tritium.parse_headers_v1"] = parse_headers_v1

--- a/whale/functions.go
+++ b/whale/functions.go
@@ -487,6 +487,10 @@ func html_doc_libxml_292_Text_Text(ctx *EngineContext, scope *Scope, ins protofa
 }
 
 func json_to_xml_v1(ctx *EngineContext, scope *Scope, ins protoface.Instruction, args []interface{}) (returnValue interface{}) {
+	return json_to_xml_libxml_legacy(ctx, scope, ins, args)
+}
+
+func json_to_xml_libxml_legacy(ctx *EngineContext, scope *Scope, ins protoface.Instruction, args []interface{}) (returnValue interface{}) {
 	// unmarshal the json
 	jsonSrc := scope.Value.(string)
 	var jsonVal interface{}
@@ -499,10 +503,57 @@ func json_to_xml_v1(ctx *EngineContext, scope *Scope, ins protoface.Instruction,
 	}
 
 	// convert to an xml doc and run the supplied block on it
-	ctx.HtmlTransformer.CreateEmptyDocument(nil, nil)
-	jsonNodes := json_to_node(jsonVal, ctx.HtmlTransformer)
+	newxform := goku_legacy.NewXForm()
+
+	newxform.CreateEmptyDocument(nil, nil)
+	ctx.AddMemoryObject(newxform)
+
+	jsonNodes := json_to_node(jsonVal, newxform)
 	// put the jsonNodes under a new root node to get the xpath searches to be correctly scoped
-	jsonRoot := ctx.HtmlTransformer.CreateElementNode("json")
+	jsonRoot := newxform.CreateElementNode("json")
+	jsonRoot.InsertTop(jsonNodes)
+	newScope := &Scope{Value: jsonRoot}
+
+	for i := 0; i < ins.INumChildren(); i++ {
+		child := ins.IGetNthChild(i)
+		ctx.RunInstruction(newScope, child)
+	}
+
+	// convert back to native Go data structures and re-marshal
+	jsonVal = node_to_json(jsonRoot.FirstChild())
+	jsonOut, err := json.MarshalIndent(jsonVal, "", "  ")
+	if err != nil {
+		// invalid JSON -- log an error message and keep going
+		LogEngineError(ctx, "json_encoding err: "+err.Error())
+		returnValue = "null"
+		return
+	}
+	scope.Value = string(jsonOut)
+	returnValue = scope.Value
+	return
+}
+
+func json_to_xml_libxml_292(ctx *EngineContext, scope *Scope, ins protoface.Instruction, args []interface{}) (returnValue interface{}) {
+	// unmarshal the json
+	jsonSrc := scope.Value.(string)
+	var jsonVal interface{}
+	err := json.Unmarshal([]byte(jsonSrc), &jsonVal)
+	if err != nil {
+		// invalid JSON -- log an error message and keep going
+		LogEngineError(ctx, "json_decoding err: "+err.Error())
+		returnValue = "null"
+		return
+	}
+
+	// convert to an xml doc and run the supplied block on it
+	newxform := goku.NewXForm()
+
+	newxform.CreateEmptyDocument(nil, nil)
+	ctx.AddMemoryObject(newxform)
+
+	jsonNodes := json_to_node(jsonVal, newxform)
+	// put the jsonNodes under a new root node to get the xpath searches to be correctly scoped
+	jsonRoot := newxform.CreateElementNode("json")
 	jsonRoot.InsertTop(jsonNodes)
 	newScope := &Scope{Value: jsonRoot}
 

--- a/whale/functions.go
+++ b/whale/functions.go
@@ -690,7 +690,7 @@ func html_fragment_doc_libxml_legacy_Text_Text(ctx *EngineContext, scope *Scope,
 	outputEncoding := args[1].(string)
 	outputEncodingBytes := []byte(outputEncoding)
 	input := scope.Value.(string)
-	_, err := xform.ParseFragment([]byte(input), inputEncodingBytes, nil, outputEncodingBytes)
+	fragment, err := xform.ParseFragment([]byte(input), inputEncodingBytes, nil, outputEncodingBytes)
 	if err != nil {
 		LogEngineError(ctx, "html_fragment err: "+err.Error())
 		returnValue = "false"
@@ -702,9 +702,8 @@ func html_fragment_doc_libxml_legacy_Text_Text(ctx *EngineContext, scope *Scope,
 	defer func() { ctx.HtmlTransformer = prevxform }()
 
 	ctx.HtmlTransformer = xform
-	frag, _ := xform.Root()
 
-	ns := &Scope{Value: frag}
+	ns := &Scope{Value: fragment}
 	for i := 0; i < ins.INumChildren(); i++ {
 		child := ins.IGetNthChild(i)
 		ctx.RunInstruction(ns, child)
@@ -724,7 +723,7 @@ func html_fragment_doc_libxml_292_Text_Text(ctx *EngineContext, scope *Scope, in
 	outputEncoding := args[1].(string)
 	outputEncodingBytes := []byte(outputEncoding)
 	input := scope.Value.(string)
-	_, err := xform.ParseFragment([]byte(input), inputEncodingBytes, nil, outputEncodingBytes)
+	fragment, err := xform.ParseFragment([]byte(input), inputEncodingBytes, nil, outputEncodingBytes)
 	if err != nil {
 		LogEngineError(ctx, "html_fragment err: "+err.Error())
 		returnValue = "false"
@@ -736,9 +735,8 @@ func html_fragment_doc_libxml_292_Text_Text(ctx *EngineContext, scope *Scope, in
 	defer func() { ctx.HtmlTransformer = prevxform }()
 
 	ctx.HtmlTransformer = xform
-	frag, _ := xform.Root()
 
-	ns := &Scope{Value: frag}
+	ns := &Scope{Value: fragment}
 	for i := 0; i < ins.INumChildren(); i++ {
 		child := ins.IGetNthChild(i)
 		ctx.RunInstruction(ns, child)

--- a/whale/functions.go
+++ b/whale/functions.go
@@ -1246,6 +1246,7 @@ func css_libxml_legacy_Text(ctx *EngineContext, scope *Scope, ins protoface.Inst
 	if ctx.HtmlTransformer == nil {
 		xform := goku_legacy.NewXForm()
 		ctx.HtmlTransformer = xform
+		ctx.AddMemoryObject(xform)
 	}
 	returnValue = ctx.HtmlTransformer.ConvertCSS(args[0].(string))
 	return
@@ -1255,6 +1256,7 @@ func css_libxml_292_Text(ctx *EngineContext, scope *Scope, ins protoface.Instruc
 	if ctx.HtmlTransformer == nil {
 		xform := goku.NewXForm()
 		ctx.HtmlTransformer = xform
+		ctx.AddMemoryObject(xform)
 	}
 	returnValue = ctx.HtmlTransformer.ConvertCSS(args[0].(string))
 	return


### PR DESCRIPTION
There was an object being created that was not being tracked, and thus was not being freed.
This changes ensures the object is tracked and freed.