### PR TITLE
use a hash map instead of go-cache for xpath expressions, and properly c...

### DIFF
--- a/engine.go
+++ b/engine.go
@@ -15,6 +15,6 @@ type Exhaust struct {
 
 type Engine interface {
 	Run(transform protoface.Transform, rrules []protoface.RewriteRule, input interface{}, vars, constants map[string]string, deadline time.Time, customer, project, messagePath string, activeLayers []string, inDebug bool) *Exhaust
-	GetCacheStats() (int, int, int, int)
+	GetCacheStats() (int, int)
 	Free()
 }

--- a/htmltransformer/gokogiri_interface/node.go
+++ b/htmltransformer/gokogiri_interface/node.go
@@ -8,6 +8,7 @@ import (
 	"gokogiri/xml"
 	"gokogiri/xpath"
 	ht "tritium/htmltransformer"
+	"tritium/tritstrings"
 )
 
 type GokogiriXmlNode struct {
@@ -160,7 +161,7 @@ func (node *GokogiriXmlNode) SelectXPath(data interface{}) (results []ht.Node, e
 		case xpath.Expression:
 			res, err = node.innernode.Search(&typecasted)
 		default:
-			return nil, errors.New("Unexpected xpath type!")
+			return nil, errors.New(tritstrings.UNKNOWN_XPATH_TYPE_ERR)
 		}
 	case GokogiriXPathSelector:
 		res, err = node.innernode.Search(&xptype.Expression)
@@ -185,14 +186,14 @@ func (node *GokogiriXmlNode) SelectXPathByDeadline(data interface{}, deadline *t
 		case xpath.Expression:
 			res, err = node.innernode.SearchByDeadline(&typecasted, deadline)
 		default:
-			return nil, errors.New("Unexpected xpath type!")
+			return nil, errors.New(tritstrings.UNKNOWN_XPATH_TYPE_ERR)
 		}
 	case GokogiriXPathSelector:
 		res, err = node.innernode.SearchByDeadline(&xptype.Expression, deadline)
 	case string:
 		res, err = node.innernode.SearchByDeadline(data, deadline)
 	default:
-		return nil, errors.New("Unexpected xpath type!")
+		return nil, errors.New(tritstrings.UNKNOWN_XPATH_TYPE_ERR)
 	}
 
 	results = make([]ht.Node, len(res))

--- a/htmltransformer/gokogiri_interface/node.go
+++ b/htmltransformer/gokogiri_interface/node.go
@@ -1,10 +1,12 @@
 package gokogiri_interface
 
 import (
+	"errors"
+	"time"
+
 	"gokogiri/css"
 	"gokogiri/xml"
 	"gokogiri/xpath"
-	"time"
 	ht "tritium/htmltransformer"
 )
 
@@ -158,6 +160,7 @@ func (node *GokogiriXmlNode) SelectXPath(data interface{}) (results []ht.Node, e
 		case xpath.Expression:
 			res, err = node.innernode.Search(&typecasted)
 		default:
+			return nil, errors.New("Unexpected xpath type!")
 		}
 	case GokogiriXPathSelector:
 		res, err = node.innernode.Search(&xptype.Expression)
@@ -182,12 +185,14 @@ func (node *GokogiriXmlNode) SelectXPathByDeadline(data interface{}, deadline *t
 		case xpath.Expression:
 			res, err = node.innernode.SearchByDeadline(&typecasted, deadline)
 		default:
+			return nil, errors.New("Unexpected xpath type!")
 		}
 	case GokogiriXPathSelector:
 		res, err = node.innernode.SearchByDeadline(&xptype.Expression, deadline)
 	case string:
 		res, err = node.innernode.SearchByDeadline(data, deadline)
 	default:
+		return nil, errors.New("Unexpected xpath type!")
 	}
 
 	results = make([]ht.Node, len(res))

--- a/htmltransformer/gokogiri_interface_legacy/node.go
+++ b/htmltransformer/gokogiri_interface_legacy/node.go
@@ -1,10 +1,12 @@
 package gokogiri_interface_legacy
 
 import (
+	"errors"
+	"time"
+
 	"gokogiri_legacy/css"
 	"gokogiri_legacy/xml"
 	"gokogiri_legacy/xpath"
-	"time"
 	ht "tritium/htmltransformer"
 )
 
@@ -158,6 +160,7 @@ func (node *GokogiriXmlNode) SelectXPath(data interface{}) (results []ht.Node, e
 		case xpath.Expression:
 			res, err = node.innernode.Search(&typecasted)
 		default:
+			return nil, errors.New("Unexpected xpath type!")
 		}
 	case GokogiriXPathSelector:
 		res, err = node.innernode.Search(&xptype.Expression)
@@ -182,12 +185,14 @@ func (node *GokogiriXmlNode) SelectXPathByDeadline(data interface{}, deadline *t
 		case xpath.Expression:
 			res, err = node.innernode.SearchByDeadline(&typecasted, deadline)
 		default:
+			return nil, errors.New("Unexpected xpath type!")
 		}
 	case GokogiriXPathSelector:
 		res, err = node.innernode.SearchByDeadline(&xptype.Expression, deadline)
 	case string:
 		res, err = node.innernode.SearchByDeadline(data, deadline)
 	default:
+		return nil, errors.New("Unexpected xpath type!")
 	}
 
 	results = make([]ht.Node, len(res))

--- a/htmltransformer/gokogiri_interface_legacy/node.go
+++ b/htmltransformer/gokogiri_interface_legacy/node.go
@@ -8,6 +8,7 @@ import (
 	"gokogiri_legacy/xml"
 	"gokogiri_legacy/xpath"
 	ht "tritium/htmltransformer"
+	"tritium/tritstrings"
 )
 
 type GokogiriXmlNode struct {
@@ -160,7 +161,7 @@ func (node *GokogiriXmlNode) SelectXPath(data interface{}) (results []ht.Node, e
 		case xpath.Expression:
 			res, err = node.innernode.Search(&typecasted)
 		default:
-			return nil, errors.New("Unexpected xpath type!")
+			return nil, errors.New(tritstrings.UNKNOWN_XPATH_TYPE_ERR)
 		}
 	case GokogiriXPathSelector:
 		res, err = node.innernode.Search(&xptype.Expression)
@@ -185,14 +186,14 @@ func (node *GokogiriXmlNode) SelectXPathByDeadline(data interface{}, deadline *t
 		case xpath.Expression:
 			res, err = node.innernode.SearchByDeadline(&typecasted, deadline)
 		default:
-			return nil, errors.New("Unexpected xpath type!")
+			return nil, errors.New(tritstrings.UNKNOWN_XPATH_TYPE_ERR)
 		}
 	case GokogiriXPathSelector:
 		res, err = node.innernode.SearchByDeadline(&xptype.Expression, deadline)
 	case string:
 		res, err = node.innernode.SearchByDeadline(data, deadline)
 	default:
-		return nil, errors.New("Unexpected xpath type!")
+		return nil, errors.New(tritstrings.UNKNOWN_XPATH_TYPE_ERR)
 	}
 
 	results = make([]ht.Node, len(res))

--- a/tritstrings/strings.go
+++ b/tritstrings/strings.go
@@ -1,8 +1,9 @@
 package tritstrings
 
 const (
-	SQUID_PARSER_LAYER_NOT_GIVEN_ERR = "%s:%d -- required layer not provided; please make sure you've specified all necessary layers in the start-up options"
+	SQUID_PARSER_LAYER_NOT_GIVEN_ERR        = "%s:%d -- required layer not provided; please make sure you've specified all necessary layers in the start-up options"
 	SQUID_PARSER_AMBIGUOUS_LAYER_IMPORT_ERR = "%s:%d -- layer imports may not be used when multiple layers are active"
-	SQUID_PARSER_LAYER_FILE_NOT_FOUND_ERR = "%s:%d -- required layer import (%s) has no corresponding Tritium file (want %s)"
-	UTIL_INVALID_LAYER_NAME_ERR = "Provided layer name `%s` is not allowed; please consult documentation on layers at http://developer.moovweb.com."
+	SQUID_PARSER_LAYER_FILE_NOT_FOUND_ERR   = "%s:%d -- required layer import (%s) has no corresponding Tritium file (want %s)"
+	UTIL_INVALID_LAYER_NAME_ERR             = "Provided layer name `%s` is not allowed; please consult documentation on layers at http://developer.moovweb.com."
+	UNKNOWN_XPATH_TYPE_ERR                  = "Unexpected xpath type!"
 )

--- a/whale/functions.go
+++ b/whale/functions.go
@@ -800,10 +800,6 @@ func html_fragment_doc_libxml_292_Text_Text(ctx *EngineContext, scope *Scope, in
 }
 
 func select_Text(ctx *EngineContext, scope *Scope, ins protoface.Instruction, args []interface{}) (returnValue interface{}) {
-	return select_libxml_legacy_Text(ctx, scope, ins, args)
-}
-
-func select_libxml_legacy_Text(ctx *EngineContext, scope *Scope, ins protoface.Instruction, args []interface{}) (returnValue interface{}) {
 	node := scope.Value.(hx.Node)
 	xpathStr := args[0].(string)
 	expr := ctx.GetXpathExpr(xpathStr)

--- a/whale/whale.go
+++ b/whale/whale.go
@@ -21,7 +21,8 @@ import (
 type Whale struct {
 	Debugger    steno.Debugger
 	RegexpCache cache.Cache
-	XPathCache  cache.Cache
+	XPathCache  map[string]hx.Selector
+	// XPathCache  cache.Cache
 }
 
 type EngineContext struct {
@@ -71,10 +72,9 @@ func NewEngine(debugger steno.Debugger) *Whale {
 	e := &Whale{
 		Debugger:    debugger,
 		RegexpCache: arc.NewARCache(1000),
-		XPathCache:  arc.NewARCache(1000),
+		XPathCache:  make(map[string]hx.Selector),
 	}
 	e.RegexpCache.SetCleanFunc(CleanRegexpObject)
-	e.XPathCache.SetCleanFunc(CleanXpathExpObject)
 	return e
 }
 
@@ -109,13 +109,19 @@ func NewEngineCtx(eng *Whale, vars, constants map[string]string, transform proto
 
 func (eng *Whale) Free() {
 	eng.RegexpCache.Reset()
-	eng.XPathCache.Reset()
+	for k, e := range eng.XPathCache {
+		if e != nil {
+			e.Free()
+		}
+		eng.XPathCache[k] = nil
+		delete(eng.XPathCache, k)
+	}
 }
 
 func (eng *Whale) Run(transform protoface.Transform, rrules []protoface.RewriteRule, input interface{}, vars, constants map[string]string, deadline time.Time, customer, project, messagePath string, activeLayers []string, inDebug bool) (exhaust *tritium.Exhaust) {
 	ctx := NewEngineCtx(eng, vars, constants, transform, rrules, deadline, messagePath, customer, project, activeLayers, inDebug)
 	exhaust = &tritium.Exhaust{}
-	defer ctx.Free()
+	defer ctx.Whale.Free()
 	ctx.Yields = append(ctx.Yields, &YieldBlock{Vars: make(map[string]interface{})})
 	ctx.UsePackage(transform.IGetPkg())
 	scope := &Scope{Value: input.(string)}
@@ -132,8 +138,8 @@ func (eng *Whale) Run(transform protoface.Transform, rrules []protoface.RewriteR
 	return
 }
 
-func (eng *Whale) GetCacheStats() (int, int, int, int) {
-	return eng.RegexpCache.GetHitRate(), eng.RegexpCache.GetUsageRate(), eng.XPathCache.GetHitRate(), eng.XPathCache.GetUsageRate()
+func (eng *Whale) GetCacheStats() (int, int) {
+	return eng.RegexpCache.GetHitRate(), eng.RegexpCache.GetUsageRate()
 }
 
 func (ctx *EngineContext) Free() {
@@ -395,18 +401,18 @@ func (ctx *EngineContext) GetRegexp(pattern, options string) (r *rubex.Regexp) {
 }
 
 func (ctx *EngineContext) GetXpathExpr(p string) (e hx.Selector) {
-	object, err := ctx.XPathCache.Get(p)
-	if err != nil {
+	object, there := ctx.XPathCache[p]
+	if !there {
 		e = ctx.HtmlTransformer.CompileXPath(p)
 		if e != nil {
 			//ctx.AddMemoryObject(e)
-			ctx.XPathCache.Set(p, &XpathExpObject{e})
+			ctx.XPathCache[p] = e
 		} else {
 			ctx.Debugger.LogTritiumErrorMessage(ctx.Customer, ctx.Project, ctx.Env, ctx.MessagePath, "Invalid XPath used: "+p)
 		}
 		return e
 	}
-	return object.(*XpathExpObject)
+	return object
 }
 
 func (ctx *EngineContext) AddExport(exports []string) {


### PR DESCRIPTION
...all whale.free() at the end of the request.

squashed commits:
cleaner logs

print number of xpath expressions in a run

check if the debug file is there and if not, create it

tests were failing, probably because of bad casts in the log statements

try not getting xpaths from gocache

only log where we know it breaks