### PR TITLE
[PFST-502] Set FlagSet's output to Stdout so that Golang can validate the messages

### DIFF
--- a/proto/slugviewer/slugviewer.go
+++ b/proto/slugviewer/slugviewer.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"fmt"
 	"io/ioutil"
+	"os"
 	"strings"
 	"time"
 )
@@ -25,6 +26,7 @@ type SlugViewCmd struct {
 func New() *SlugViewCmd {
 	cmd := SlugViewCmd{}
 	cmd.flags = flag.NewFlagSet(CmdName, flag.ContinueOnError)
+	cmd.flags.SetOutput(os.Stdout)
 	cmd.options = &Options{}
 
 	cmd.options.SetDefaults()


### PR DESCRIPTION
This is related to a PR "[PFST-502] Moov SDK Errors drowned out by output of usage help text" in manhattan.
https://github.com/moovweb/manhattan/pull/1333